### PR TITLE
fix: revert to original app behavior of empty string if created_by not found

### DIFF
--- a/react_ui/src/components/map_data_points/MapDataPointModal.tsx
+++ b/react_ui/src/components/map_data_points/MapDataPointModal.tsx
@@ -79,7 +79,7 @@ class MapDataPointModal extends React.Component<
     const credit = `${
       note.created_by && (note.created_by as CreatedBy).username
         ? (note.created_by as CreatedBy).username
-        : user.username
+        : ""
     } ${formatTimestamp(note.created_at)}`;
 
     const tag = (note.tags || ["New"])[0];


### PR DESCRIPTION
Revert to original app behavior of empty string if created_by not found